### PR TITLE
Fixed the incorrect configure option and now we can compile binaries for...

### DIFF
--- a/configure_i386.sh
+++ b/configure_i386.sh
@@ -1,5 +1,4 @@
 DEVELOPER="$(xcode-select --print-path)"
-SDKROOT="$(xcodebuild -version -sdk iphonesimulator | grep -E '^Path' | sed 's/Path: //')"
 ARCH="i386"
 
 ICU_PATH="$(pwd)/icu"
@@ -7,12 +6,12 @@ ICU_FLAGS="-I$ICU_PATH/source/common/ -I$ICU_PATH/source/tools/tzcode/ "
 
 export CXX="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
 export CC="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
-export CFLAGS="-isysroot $SDKROOT -I$SDKROOT/usr/include/ -I./include/ -arch $ARCH -miphoneos-version-min=7.0 $ICU_FLAGS"
-export CXXFLAGS="-stdlib=libc++ -std=c++11 -isysroot $SDKROOT -I$SDKROOT/usr/include/ -I./include/ -arch $ARCH -miphoneos-version-min=7.0 $ICU_FLAGS"
-export LDFLAGS="-stdlib=libc++ -L$SDKROOT/usr/lib/ -isysroot $SDKROOT -Wl,-dead_strip -miphoneos-version-min=7.0 -lstdc++"
+export CFLAGS="-arch $ARCH $ICU_FLAGS"
+export CXXFLAGS="-stdlib=libc++ -std=c++11 -arch $ARCH $ICU_FLAGS"
+export LDFLAGS="-stdlib=libc++ -Wl,-dead_strip -lstdc++"
 
 mkdir -p build-$ARCH && cd build-$ARCH
 
 [ -e Makefile ] && make distclean
 
-sh $ICU_PATH/source/configure --host=i686-apple-darwin11 --enable-static --disable-shared
+sh $ICU_PATH/source/configure --enable-static --disable-shared

--- a/configure_x86_64.sh
+++ b/configure_x86_64.sh
@@ -1,5 +1,4 @@
 DEVELOPER="$(xcode-select --print-path)"
-SDKROOT="$(xcodebuild -version -sdk iphonesimulator | grep -E '^Path' | sed 's/Path: //')"
 ARCH="x86_64"
 
 ICU_PATH="$(pwd)/icu"
@@ -7,12 +6,12 @@ ICU_FLAGS="-I$ICU_PATH/source/common/ -I$ICU_PATH/source/tools/tzcode/ "
 
 export CXX="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
 export CC="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
-export CFLAGS="-isysroot $SDKROOT -I$SDKROOT/usr/include/ -I./include/ -arch $ARCH -miphoneos-version-min=5.0 $ICU_FLAGS"
-export CXXFLAGS="-stdlib=libc++ -std=c++11 -isysroot $SDKROOT -I$SDKROOT/usr/include/ -I./include/ -arch $ARCH -miphoneos-version-min=5.0 $ICU_FLAGS"
-export LDFLAGS="-stdlib=libc++ -L$SDKROOT/usr/lib/ -isysroot $SDKROOT -Wl,-dead_strip -miphoneos-version-min=5.0 -lstdc++"
+export CFLAGS="-arch $ARCH $ICU_FLAGS"
+export CXXFLAGS="-stdlib=libc++ -std=c++11 -arch $ARCH $ICU_FLAGS"
+export LDFLAGS="-stdlib=libc++ -Wl,-dead_strip -lstdc++"
 
 mkdir -p build-$ARCH && cd build-$ARCH
 
 [ -e Makefile ] && make distclean
 
-sh $ICU_PATH/source/configure --host=i686-apple-darwin11 --enable-static --disable-shared
+sh $ICU_PATH/source/configure --enable-static --disable-shared


### PR DESCRIPTION
Hi, all.
I found that `configure_x86_64.sh` caused a configure error and fixed it.
Please check my changes on your machine.
# Environment

```
shinya_yamaoka@syamaoka% uname -a
Darwin syamaoka.local 13.4.0 Darwin Kernel Version 13.4.0: Sun Aug 17 19:50:11 PDT 2014; root:xnu-2422.115.4~1/RELEASE_X86_64 x86_64 i386 MacBookPro8,1 Darwin

shinya_yamaoka@syamaoka% clang -v
Apple LLVM version 6.0 (clang-600.0.54) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin13.4.0
Thread model: posix

shinya_yamaoka@syamaoka% xcodebuild -version
Xcode 6.1
Build version 6A1052d
```
# Problem
## configure_x86_64.sh generates a configure error

Here is the configure error which I got:

```
shinya_yamaoka@syamaoka% ./configure_x86_64.sh 
checking for ICU version numbers... release 54.1, library 54.1, unicode version 7.0
checking build system type... x86_64-apple-darwin13.4.0
checking host system type... i686-apple-darwin11
checking whether to build debug libraries... no
checking whether to build release libraries... yes
checking for i686-apple-darwin11-clang... /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
checking whether the C compiler works... no
configure: error: in `/Users/shinya_yamaoka/repos/mine/icu-ios-shinnya/build-x86_64':
configure: error: C compiler cannot create executables
See `config.log' for more details
```

Open `build-x86_64/config.log` and the error messages like below are shown in the log:

```
configure:2962: checking whether the C compiler works
configure:2984: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.1.sdk -I/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.1.sdk/usr/include/ -I./include/ -arch x86_64 -miphoneos-version-min=5.0 -I/Users/shinya_yamaoka/repos/mine/icu-ios-shinnya/icu/source/common/ -I/Users/shinya_yamaoka/repos/mine/icu-ios-shinnya/icu/source/tools/tzcode/   -stdlib=libc++ -L/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.1.sdk/usr/lib/ -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.1.sdk -Wl,-dead_strip -miphoneos-version-min=5.0 -lstdc++ conftest.c  >&5
ld: entry point (start) undefined.  Usually in crt1.o for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

On Mac OSX, the ld entry point is not `_start` but `_main`, so ld command shows an error message. But this is not the root cause of the configure error.
It is the issue that we give a incorrect configure option in `configure_x86_64.sh`.
# Solution

According to http://source.icu-project.org/repos/icu/icu/trunk/readme.html#HowToCrossCompileICU, we should not specify `--host` configure option on generating `x86_64` static libraries. `--host` option must be specified only on generating binaries for iOS. Then, when we give `--host` configure option, we must give `--with-cross-build` configure option too.

Best Regards.
